### PR TITLE
Insert items at proper place

### DIFF
--- a/app/CLI.hs
+++ b/app/CLI.hs
@@ -23,7 +23,7 @@ present = not.null
 
 autoPlaylists :: Int -> Client ()
 autoPlaylists count = do
-  tournamentsWithVideos <- lastTournaments count
+  tournamentsWithVideos <- reverse <$> lastTournaments count
   let tournaments = map fst tournamentsWithVideos
   playlists <- createPlaylists tournaments
   tournamentsWithNewVideos <- onlyNewVideos playlists tournamentsWithVideos

--- a/src/YouTube.hs
+++ b/src/YouTube.hs
@@ -70,14 +70,14 @@ findChannel name =
                        , ("forUsername", name              )
                        ]
 
-insertVideo :: Video -> Playlist -> Client Success
-insertVideo v p = do
+insertVideo :: Video -> Int -> Playlist -> Client Success
+insertVideo v pos pl = do
   needsUserCredentials
   post "/playlistItems" parameters body
     where parameters = [ ("part", "snippet") ]
-          body = Just (PlaylistItem "" vId pId 0)
+          body = Just (PlaylistItem "" vId pId pos)
           vId = videoId v
-          pId = playlistId p
+          pId = playlistId pl
 
 listPlaylist :: YouTubeId -> Int -> Client Videos
 listPlaylist pId count = do


### PR DESCRIPTION
Let restart indexing from anywhere.

To test: create playlist, drop 1 item and restart : dropped item should be in the proper place.
